### PR TITLE
Fixed crash when the text is too short.

### DIFF
--- a/readmoretextview/src/main/java/com/borjabravo/readmoretextview/ReadMoreTextView.java
+++ b/readmoretextview/src/main/java/com/borjabravo/readmoretextview/ReadMoreTextView.java
@@ -113,7 +113,9 @@ public class ReadMoreTextView extends TextView {
         if (trimMode == TRIM_MODE_LINES) {
             if (text != null && lineEndIndex > 0) {
                 if (readMore) {
-                    return updateCollapsedText();
+                    if (getLayout().getLineCount() > trimLines) {
+                        return updateCollapsedText();
+                    }
                 } else {
                     return updateExpandedText();
                 }


### PR DESCRIPTION
The view crashed when the text is too short as the spannable index becomes negative.