### PR TITLE
Fixing issue #28. 

### DIFF
--- a/readmoretextview/src/main/java/com/borjabravo/readmoretextview/ReadMoreTextView.java
+++ b/readmoretextview/src/main/java/com/borjabravo/readmoretextview/ReadMoreTextView.java
@@ -81,6 +81,7 @@ public class ReadMoreTextView extends TextView {
     }
 
     private void setText() {
+        super.setText(text, bufferType);
         super.setText(getDisplayableText(), bufferType);
         setMovementMethod(LinkMovementMethod.getInstance());
         setHighlightColor(Color.TRANSPARENT);


### PR DESCRIPTION
When recycling a view with RecyclerView, the text needs to be set to the view before trying to measure displayable text due to recycled text being present and of a different length. Prevents the StringIndexOutOfBoundsException.